### PR TITLE
Add Custom 404 page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -9,7 +9,7 @@ export default ({props, data}) => (
   <Layout>
     <Seo
       title={`About ${data.site.siteMetadata.title}`}
-      description={data.markdownRemark.frontmatter.title} />
+      description={data.site.siteMetadata.description} />
  
     <div className="mw9 center flex flex-wrap pv5-l w-100">
       <div className="mw7 w-100 pa2">
@@ -31,20 +31,8 @@ export const dataQuery = graphql`
   query {
     site {
       siteMetadata {
-        title
-      }
-    }
-    markdownRemark(frontmatter: {name: {eq: "about__bio"}}) {
-      html
-      frontmatter {
-        title
-      }
-    }
-    banner: file(relativePath: {eq: "img/about__banner.jpg"}) {
-      childImageSharp {
-        fluid(maxHeight: 720, maxWidth: 1920) {
-          ...GatsbyImageSharpFluid
-        }
+        title,
+        description
       }
     }
   }`

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import Layout from '../common/layouts';
+import Img from 'gatsby-image';
+import { graphql, Link } from 'gatsby';
+import Seo from '../common/seo';
+
+
+export default ({props, data}) => (
+  <Layout>
+    <Seo
+      title={`About ${data.site.siteMetadata.title}`}
+      description={data.markdownRemark.frontmatter.title} />
+ 
+    <div className="mw9 center flex flex-wrap pv5-l w-100">
+      <div className="mw7 w-100 pa2">
+
+        <h1 className="display fw1 db lh-copy"> 404 // Page Not Found</h1>
+
+        <p className="mw7 w-100 lh-copy serif pa2 flex flex-column justify-center f4" >        We couldn't find what you were looking for.</p>
+        <Link to="/" className="dib bg-dark-gray b near-white hover-bg-mid-gray pv3 ph4 ttu tracked sans-serif no-underline mv2">Go to homepage</Link>
+      </div>
+
+    </div>
+  </Layout>
+
+
+)
+
+
+export const dataQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    markdownRemark(frontmatter: {name: {eq: "about__bio"}}) {
+      html
+      frontmatter {
+        title
+      }
+    }
+    banner: file(relativePath: {eq: "img/about__banner.jpg"}) {
+      childImageSharp {
+        fluid(maxHeight: 720, maxWidth: 1920) {
+          ...GatsbyImageSharpFluid
+        }
+      }
+    }
+  }`

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -16,7 +16,7 @@ export default ({props, data}) => (
 
         <h1 className="display fw1 db lh-copy"> 404 // Page Not Found</h1>
 
-        <p className="mw7 w-100 lh-copy serif pa2 flex flex-column justify-center f4" >        We couldn't find what you were looking for.</p>
+        <p className="mw7 w-100 lh-copy serif pa2 flex flex-column justify-center f4" >        We couldn&#39;t find what you were looking for.</p>
         <Link to="/" className="dib bg-dark-gray b near-white hover-bg-mid-gray pv3 ph4 ttu tracked sans-serif no-underline mv2">Go to homepage</Link>
       </div>
 


### PR DESCRIPTION
Added custom 404 page to resolve 
https://github.com/madelyneriksen/gatsby-starter-tyra/issues/9
 

Display this:

<img width="1393" alt="Screen Shot 2019-03-17 at 12 03 13 PM" src="https://user-images.githubusercontent.com/6998954/54494056-ba60ed80-48ac-11e9-9b7d-5628442aa0ed.png">

Instead of generic Netlify 404 (or whatever host provider someone chooses)

<img width="1394" alt="Screen Shot 2019-03-17 at 12 10 06 PM" src="https://user-images.githubusercontent.com/6998954/54494150-ba152200-48ad-11e9-9d84-6088719d4769.png">


