### PR TITLE
add optional instagram footer link

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,7 @@ module.exports = {
     pinterest: "", // YOUR PINTEREST PROFILE HERE
     facebook: "", // YOUR FACEBOOK PROFILE HERE
     twitter: "", // YOUR TWITTER PROFILE HERE
+    instagram: "", // YOUR INSTAGRAM PROFILE HERE
   },
   plugins: [
     'gatsby-plugin-sitemap',

--- a/src/common/components/footer.js
+++ b/src/common/components/footer.js
@@ -5,7 +5,8 @@ import {
   FaFacebookF,
   FaTwitter,
   FaYoutube,
-  FaGithub
+  FaGithub,
+  FaInstagram,
 } from 'react-icons/fa';
 import 'tachyons';
 
@@ -23,6 +24,7 @@ export default () => (
             twitter
             youtube
             github
+            instagram
           }
         }
       } 
@@ -73,6 +75,12 @@ export default () => (
               {data.site.siteMetadata.twitter && (
                 <a className="near-white" href={data.site.siteMetadata.twitter}>
                   <FaTwitter />
+                </a>
+              )}
+
+              {data.site.siteMetadata.instagram && (
+                <a className="near-white" href={data.site.siteMetadata.instagram}>
+                  <FaInstagram />
                 </a>
               )}
             </div>


### PR DESCRIPTION
hey! 
at first, thx a lot for open sourcing this gatsby starter. I've just started building a website on top of it and it's absolutely great! The website I build requires a link to an Instagram profile, so this PR extends the social links section in the footer with the option to add an Instagram Link.